### PR TITLE
Fix `operator == is not supported!` Roblox-TS error

### DIFF
--- a/integrations/Roblox-ts-poly-fills.ts
+++ b/integrations/Roblox-ts-poly-fills.ts
@@ -162,12 +162,12 @@ export const lowerCase = string.lower;
 
 export const trimStart = (str: string) => {
 	let res = str;
-	while (res.sub(1, 1) == " ") res = res.sub(2, -1);
+	while (res.sub(1, 1) === " ") res = res.sub(2, -1);
 	return res;
 };
 export const trimEnd = (str: string) => {
 	let res = str;
-	while (res.sub(-1, -1) == " ") res = res.sub(1, -2);
+	while (res.sub(-1, -1) === " ") res = res.sub(1, -2);
 	return res;
 };
 


### PR DESCRIPTION
Changes the `==` operator in the Roblox-ts-poly-fills file.
Roblox TS doesn't support `==`, because of cases like `"1" == 1` being true